### PR TITLE
Updating Greece's reduced VAT rate from 6.5% to 6.0%.

### DIFF
--- a/resources/tax_type/gr_vat.json
+++ b/resources/tax_type/gr_vat.json
@@ -83,7 +83,13 @@
                 {
                     "id": "gr_vat_reduced_2011",
                     "amount": 0.065,
-                    "start_date": "2011-01-01"
+                    "start_date": "2011-01-01",
+                    "end_date": "2015-06-30"
+                },
+                {
+                    "id": "gr_vat_reduced_2015",
+                    "amount": 0.06,
+                    "start_date": "2015-07-01"
                 }
             ]
         }


### PR DESCRIPTION
References:
* http://www.vatlive.com/european-news/greece-new-vat-rises-in-creditor-talks/
* http://www.accordancevat.com/greece-vat-rate-changes-july-2015/