### PR TITLE
Added Australian GST tax type and zone.

### DIFF
--- a/resources/tax_type/au_gst.json
+++ b/resources/tax_type/au_gst.json
@@ -1,0 +1,21 @@
+{
+    "name": "Australian GST",
+    "generic_label": "gst",
+    "display_inclusive": true,
+    "zone": "au_gst",
+    "tag": "AU",
+    "rates": [
+        {
+            "id": "au_gst_standard",
+            "name": "Standard",
+            "default": true,
+            "amounts": [
+                {
+                    "id": "au_gst_standard_2000",
+                    "amount": 0.1,
+                    "start_date": "2000-07-01"
+                }
+            ]
+        }
+    ]
+}

--- a/resources/zone/au_gst.json
+++ b/resources/zone/au_gst.json
@@ -1,0 +1,12 @@
+{
+    "name": "Australia (GST)",
+    "scope": "tax",
+    "members": [
+        {
+            "type": "country",
+            "id": "au_gst_0",
+            "name": "Australia",
+            "country_code": "AU"
+        }
+    ]
+}


### PR DESCRIPTION
Australia has a single consumption tax called GST (similar to VAT in Europe) which is 10% and has been since its introduction in July 2000.