### PR TITLE
Fixed copy/paste typo in Spain VAT reduced rate

### DIFF
--- a/resources/tax_type/ch_vat.json
+++ b/resources/tax_type/ch_vat.json
@@ -21,7 +21,7 @@
             "name": "Hotel",
             "amounts": [
                 {
-                    "id": "ch_vat_reduced_2011",
+                    "id": "ch_vat_hotel_2011",
                     "amount": 0.038,
                     "start_date": "2011-01-01"
                 }

--- a/resources/tax_type/es_vat.json
+++ b/resources/tax_type/es_vat.json
@@ -43,7 +43,7 @@
                     "id": "es_vat_reduced_2010",
                     "amount": 0.08,
                     "start_date": "2010-07-01",
-                    "end_date": "2012-08-31"
+                    "end_date": "2010-12-31"
                 },
                 {
                     "id": "es_vat_reduced_2011",

--- a/resources/tax_type/es_vat.json
+++ b/resources/tax_type/es_vat.json
@@ -43,12 +43,12 @@
                     "id": "es_vat_reduced_2010",
                     "amount": 0.08,
                     "start_date": "2010-07-01",
-                    "end_date": "2010-12-31"
+                    "end_date": "2012-08-31"
                 },
                 {
-                    "id": "es_vat_reduced_2011",
+                    "id": "es_vat_reduced_2012",
                     "amount": 0.1,
-                    "start_date": "2011-01-01"
+                    "start_date": "2012-09-01"
                 }
             ]
         },

--- a/resources/tax_type/pt_vat.json
+++ b/resources/tax_type/pt_vat.json
@@ -25,7 +25,8 @@
                 {
                     "id": "pt_vat_standard_2010",
                     "amount": 0.21,
-                    "start_date": "2010-12-31"
+                    "start_date": "2010-07-01",
+                    "end_date": "2010-12-31"
                 },
                 {
                     "id": "pt_vat_standard_2011",


### PR DESCRIPTION
For Spain reduced rate, it appears that cutoff dates are not consistent.
This must be a consequence of an above cutoff date (from "es_vat_standard_2010") being copy/pasted and not edited.