### PR TITLE
Added missing years to amount identifiers to avoid ambiguities

### DIFF
--- a/resources/tax_type/be_vat.json
+++ b/resources/tax_type/be_vat.json
@@ -44,7 +44,7 @@
             "name": "Zero",
             "amounts": [
                 {
-                    "id": "be_vat_zero",
+                    "id": "be_vat_zero_1971",
                     "amount": 0,
                     "start_date": "1971-01-01"
                 }

--- a/resources/tax_type/cz_vat.json
+++ b/resources/tax_type/cz_vat.json
@@ -69,7 +69,7 @@
             "name": "Zero",
             "amounts": [
                 {
-                    "id": "cz_vat_zero",
+                    "id": "cz_vat_zero_2004",
                     "amount": 0,
                     "start_date": "2004-05-01"
                 }

--- a/resources/tax_type/dk_vat.json
+++ b/resources/tax_type/dk_vat.json
@@ -22,7 +22,7 @@
             "name": "Zero",
             "amounts": [
                 {
-                    "id": "dk_vat_zero",
+                    "id": "dk_vat_zero_1973",
                     "amount": 0,
                     "start_date": "1973-01-01"
                 }

--- a/resources/tax_type/gb_vat.json
+++ b/resources/tax_type/gb_vat.json
@@ -51,7 +51,7 @@
             "name": "Zero",
             "amounts": [
                 {
-                    "id": "gb_vat_zero",
+                    "id": "gb_vat_zero_1973",
                     "amount": 0,
                     "start_date": "1973-01-01"
                 }

--- a/resources/tax_type/hr_vat.json
+++ b/resources/tax_type/hr_vat.json
@@ -39,7 +39,7 @@
             "name": "Zero",
             "amounts": [
                 {
-                    "id": "hr_vat_zero",
+                    "id": "hr_vat_zero_2013",
                     "amount": 0,
                     "start_date": "2013-07-01"
                 }

--- a/resources/tax_type/ie_vat.json
+++ b/resources/tax_type/ie_vat.json
@@ -85,7 +85,7 @@
             "name": "Zero",
             "amounts": [
                 {
-                    "id": "ie_vat_zero",
+                    "id": "ie_vat_zero_1972",
                     "amount": 0,
                     "start_date": "1972-04-01"
                 }


### PR DESCRIPTION
In this PR, I suggest minor renames of identifiers for some zero VAT rates in order to avoid ambiguities.
It's up to you!
Cheers
