### PR TITLE
Updating Greece VAT rate from 23% to 24% as of 2016-06-01.

### DIFF
--- a/resources/tax_type/gr_vat.json
+++ b/resources/tax_type/gr_vat.json
@@ -26,6 +26,11 @@
                     "id": "gr_vat_standard_2010_07",
                     "amount": 0.23,
                     "start_date": "2010-07-01"
+                },
+                {
+                    "id": "gr_vat_standard_2016_06",
+                    "amount": 0.24,
+                    "start_date": "2016-06-01"
                 }
             ]
         },


### PR DESCRIPTION
References:
- http://www.vatlive.com/vat-rates/european-vat-rates/eu-vat-rates/
- http://www.vatlive.com/european-news/greece-raises-vat-rate-to-24-2017/
- https://en.wikipedia.org/wiki/Taxation_in_Greece#VAT
