### PR TITLE
Minor update: Adds swiss vat rates from 1995-2010

### DIFF
--- a/resources/tax_type/ch_vat.json
+++ b/resources/tax_type/ch_vat.json
@@ -10,6 +10,12 @@
             "default": true,
             "amounts": [
                 {
+                    "id": "ch_vat_standard_1995",
+                    "amount": 0.076,
+                    "start_date": "1995-01-01",
+                    "end_date": "2010-12-31"
+                },
+                {
                     "id": "ch_vat_standard_2011",
                     "amount": 0.08,
                     "start_date": "2011-01-01"
@@ -21,6 +27,12 @@
             "name": "Hotel",
             "amounts": [
                 {
+                    "id": "ch_vat_hotel_1995",
+                    "amount": 0.036,
+                    "start_date": "1995-01-01",
+                    "end_date": "2010-12-31"
+                },
+                {
                     "id": "ch_vat_hotel_2011",
                     "amount": 0.038,
                     "start_date": "2011-01-01"
@@ -31,6 +43,12 @@
             "id": "ch_vat_reduced",
             "name": "Reduced",
             "amounts": [
+                {
+                    "id": "ch_vat_reduced_1995",
+                    "amount": 0.024,
+                    "start_date": "1995-01-01",
+                    "end_date": "2010-12-31"
+                },
                 {
                     "id": "ch_vat_reduced_2011",
                     "amount": 0.025,


### PR DESCRIPTION
I just added the general vat rates for Switzerland from 1995-2010 (according to this information https://de.wikipedia.org/wiki/Mehrwertsteuer_(Schweiz)#Politik) to fill the gap. Sorry the wiki article in german only.
Be aware that the article also mentions that this vat type was subjected to 26 exceptions which made it complicated to use. The exceptions basically covered parties that were excluded from paying the tax. These exceptions were all thrown out the window in the 2011 version.

I am unsure if this is the reason why this information hasn't been included yet in the project. If so feel free to reject this pull request.

On the other hand it makes me who is located in Switzerland unable to use the library since I have to get vat rates going back to 2003 in order to make my app work. I don't need those exceptions covered. I just need the vat rates for that time.