### PR TITLE
Add liechtenstein to ch zone

### DIFF
--- a/resources/tax_type/ch_vat.json
+++ b/resources/tax_type/ch_vat.json
@@ -10,6 +10,12 @@
             "default": true,
             "amounts": [
                 {
+                    "id": "ch_vat_standard_1995",
+                    "amount": 0.076,
+                    "start_date": "1995-01-01",
+                    "end_date": "2010-12-31"
+                },
+                {
                     "id": "ch_vat_standard_2011",
                     "amount": 0.08,
                     "start_date": "2011-01-01"
@@ -21,6 +27,12 @@
             "name": "Hotel",
             "amounts": [
                 {
+                    "id": "ch_vat_hotel_1995",
+                    "amount": 0.036,
+                    "start_date": "1995-01-01",
+                    "end_date": "2010-12-31"
+                },
+                {
                     "id": "ch_vat_hotel_2011",
                     "amount": 0.038,
                     "start_date": "2011-01-01"
@@ -31,6 +43,12 @@
             "id": "ch_vat_reduced",
             "name": "Reduced",
             "amounts": [
+                {
+                    "id": "ch_vat_reduced_1995",
+                    "amount": 0.024,
+                    "start_date": "1995-01-01",
+                    "end_date": "2010-12-31"
+                },
                 {
                     "id": "ch_vat_reduced_2011",
                     "amount": 0.025,

--- a/resources/zone/ch_vat.json
+++ b/resources/zone/ch_vat.json
@@ -21,6 +21,12 @@
             "name": "Italy (Lake Lugano)",
             "country_code": "IT",
             "included_postal_codes": "22060"
+        },
+        {
+            "type": "country",
+            "id": "ch_vat_3",
+            "name": "Liechtenstein",
+            "country_code": "LI"
         }
     ]
 }


### PR DESCRIPTION
Liechtenstein uses the Swiss VAT system since 1995 (see https://www.admin.ch/gov/de/start/dokumentation/medienmitteilungen.msg-id-45386.html).
This change adds it to the swiss zone file.