### PR TITLE
Critical enddate comparison operator fix

### DIFF
--- a/resources/tax_type/cz_vat.json
+++ b/resources/tax_type/cz_vat.json
@@ -76,6 +76,17 @@
             ]
         },
         {
+            "id": "cz_vat_second_reduced",
+            "name": "Second Reduced",
+            "amounts": [
+                {
+                    "id": "cz_vat_second_reduced_2015",
+                    "amount": 0.1,
+                    "start_date": "2015-01-01"
+                }
+            ]
+        },
+        {
             "id": "cz_vat_zero",
             "name": "Zero",
             "amounts": [

--- a/resources/tax_type/es_vat.json
+++ b/resources/tax_type/es_vat.json
@@ -43,7 +43,7 @@
                     "id": "es_vat_reduced_2010",
                     "amount": 0.08,
                     "start_date": "2010-07-01",
-                    "end_date": "2010-12-31"
+                    "end_date": "2012-08-31"
                 },
                 {
                     "id": "es_vat_reduced_2012",

--- a/resources/tax_type/es_vat.json
+++ b/resources/tax_type/es_vat.json
@@ -43,7 +43,7 @@
                     "id": "es_vat_reduced_2010",
                     "amount": 0.08,
                     "start_date": "2010-07-01",
-                    "end_date": "2012-08-31"
+                    "end_date": "2010-12-31"
                 },
                 {
                     "id": "es_vat_reduced_2012",

--- a/resources/tax_type/hr_vat.json
+++ b/resources/tax_type/hr_vat.json
@@ -46,6 +46,17 @@
             ]
         },
         {
+            "id": "hr_vat_super_reduced",
+            "name": "Super Reduced",
+            "amounts": [
+                {
+                    "id": "hr_vat_super_reduced_2014",
+                    "amount": 0.05,
+                    "start_date": "2014-01-01"
+                }
+            ]
+        },
+        {
             "id": "hr_vat_zero",
             "name": "Zero",
             "amounts": [

--- a/src/Model/TaxRate.php
+++ b/src/Model/TaxRate.php
@@ -180,7 +180,7 @@ class TaxRate implements TaxRateEntityInterface
             $startDate = $amount->getStartDate();
             $endDate = $amount->getEndDate();
             // Match the date against the optional amount start/end dates.
-            if ((!$startDate || $startDate <= $date) && (!$endDate || $endDate > $date)) {
+            if ((!$startDate || $startDate <= $date) && (!$endDate || $endDate >= $date)) {
                 return $amount;
             }
         }


### PR DESCRIPTION
There was an issue in the TaxRate models getAmount-function. When matching the date against the end dates the > operator was used instead of >=.
This led to a behaviour where any date that exactly matched any periods end date would not return a tax rate.