### PR TITLE
Critical fix: replaces > operator on enddate comparison with >=.

### DIFF
--- a/src/Model/TaxRate.php
+++ b/src/Model/TaxRate.php
@@ -180,7 +180,7 @@ class TaxRate implements TaxRateEntityInterface
             $startDate = $amount->getStartDate();
             $endDate = $amount->getEndDate();
             // Match the date against the optional amount start/end dates.
-            if ((!$startDate || $startDate <= $date) && (!$endDate || $endDate > $date)) {
+            if ((!$startDate || $startDate <= $date) && (!$endDate || $endDate >= $date)) {
                 return $amount;
             }
         }


### PR DESCRIPTION
There was an issue in the TaxRate models getAmount-function. When matching the date against the end dates the > operator was used instead of >=.
This led to a behaviour where any date that exactly matched any periods end date would not return a tax rate.
This fix makes sure enddates themselves are included in a tax period.