### PR TITLE
Switch postcode regexes for Azores and Madeira

### DIFF
--- a/resources/zone/pt_20_vat.json
+++ b/resources/zone/pt_20_vat.json
@@ -7,7 +7,7 @@
             "id": "pt_20_vat_0",
             "name": "Portugal (Azores)",
             "country_code": "PT",
-            "included_postal_codes": "\/(9)[0-4][0-9]{2}-[0-9]{3}\/"
+            "included_postal_codes": "\/(9)[5-9][0-9]{2}-[0-9]{3}\/"
         }
     ]
 }

--- a/resources/zone/pt_30_vat.json
+++ b/resources/zone/pt_30_vat.json
@@ -7,7 +7,7 @@
             "id": "pt_30_vat_0",
             "name": "Portugal (Madeira)",
             "country_code": "PT",
-            "included_postal_codes": "\/(9)[5-9][0-9]{2}-[0-9]{3}\/"
+            "included_postal_codes": "\/(9)[0-4][0-9]{2}-[0-9]{3}\/"
         }
     ]
 }


### PR DESCRIPTION
It looks like there is a bug where the Portugal postcode regexes for Madeira and The Azores are the wrong way round.

Reference the list here: https://en.wikipedia.org/wiki/List_of_postal_codes_in_Portugal#Ilha_da_Madeira

The Madeira ones match with the `/(9)[0-4]...` version and the Azores with `/(9)[5-9]...` one. The PR simply switches them.

There is also an issue that we are missing a pt_20_vat.json but I will address that in another PR.