### PR TITLE
Add VAT rates for The Azores

### DIFF
--- a/resources/tax_type/pt_20_vat.json
+++ b/resources/tax_type/pt_20_vat.json
@@ -1,5 +1,5 @@
 {
-  "name": "Azores VAT",
+  "name": "Azorean VAT",
   "generic_label": "vat",
   "display_inclusive": true,
   "zone": "pt_20_vat",

--- a/resources/tax_type/pt_20_vat.json
+++ b/resources/tax_type/pt_20_vat.json
@@ -1,0 +1,70 @@
+{
+  "name": "Azores VAT",
+  "generic_label": "vat",
+  "display_inclusive": true,
+  "zone": "pt_20_vat",
+  "tag": "EU",
+  "rates": [
+    {
+      "id": "pt_20_vat_standard",
+      "name": "Standard",
+      "default": true,
+      "amounts": [
+        {
+          "id": "pt_20_vat_standard_2012",
+          "amount": 0.16,
+          "end_date": "2012-03-31"
+        },
+        {
+          "id": "pt_20_vat_standard_2014",
+          "amount": 0.18,
+          "start_date": "2014-01-01"
+        }
+      ]
+    },
+    {
+      "id": "pt_20_vat_intermediate",
+      "name": "Intermediate",
+      "amounts": [
+        {
+          "id": "pt_20_vat_intermediate_2012",
+          "amount": 0.09,
+          "end_date": "2013-12-31"
+        },
+        {
+          "id": "pt_20_vat_intermediate_2014",
+          "amount": 0.10,
+          "start_date": "2014-01-01",
+          "end_date": "2015-06-30"
+        },
+        {
+          "id": "pt_20_vat_intermediate_2015",
+          "amount": 0.09,
+          "start_date": "2015-07-01"
+        }
+      ]
+    },
+    {
+      "id": "pt_20_vat_reduced",
+      "name": "Reduced",
+      "amounts": [
+        {
+          "id": "pt_20_vat_reduced_2012",
+          "amount": 0.04,
+          "end_date": "2013-12-31"
+        },
+        {
+          "id": "pt_20_vat_reduced_2014",
+          "amount": 0.05,
+          "start_date": "2014-01-01",
+          "end_date": "2015-06-30"
+        },
+        {
+          "id": "pt_20_vat_reduced_2015",
+          "amount": 0.04,
+          "start_date": "2015-07-01"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The Azores are part of the EU VAT area as per https://ec.europa.eu/taxation_customs/business/vat/eu-vat-rules-topic/territorial-status-eu-countries-certain-territories_en.

For them to be seen as part of the EU by this packages and therefore be charged VAT when receiving below threshold goods from the rest of the EU the area needs its VAT rates defined.

I have done my best to determine these but without being a Portugese speaker I'm struggling to go back beyond 2013.

**Sources**
2014-01-01: https://www.avalara.com/vatlive/en/vat-news/portugals-azores-raises-vat-18.html
2015-07-01: https://www.avalara.com/vatlive/en/vat-news/portugal-azores-reduced-vat-rates-decreased.html

For this to work correctly require the Azores/Madeira postcode PR #63