### PR TITLE
Add dutch reduced VAT 2019

### DIFF
--- a/resources/tax_type/nl_vat.json
+++ b/resources/tax_type/nl_vat.json
@@ -30,7 +30,13 @@
                 {
                     "id": "nl_vat_reduced_1986",
                     "amount": 0.06,
-                    "start_date": "1986-10-01"
+                    "start_date": "1986-10-01",
+                    "end_date": "2018-12-31"
+                },
+                {
+                    "id": "nl_vat_reduced_2019",
+                    "amount": 0.09,
+                    "start_date": "2019-01-01"
                 }
             ]
         }


### PR DESCRIPTION
The reduces vat rate is increasing in 2019 form 6% to 9%

https://www2.deloitte.com/nl/nl/pages/tax/articles/tax-plan-2019-prinsjesdag-outline.html

As of today also the senate has passed the bills.