### PR TITLE
Split out UK channel islands

### DIFF
--- a/resources/tax_type/gb_ci_vat.json
+++ b/resources/tax_type/gb_ci_vat.json
@@ -1,0 +1,21 @@
+{
+    "name": "British Channel Islands VAT",
+    "generic_label": "vat",
+    "display_inclusive": true,
+    "zone": "gb_ci_vat",
+    "tag": "EU",
+    "rates": [
+        {
+            "id": "gb_ci_vat_zero",
+            "name": "Zero",
+            "default": true,
+            "amounts": [
+                {
+                    "id": "gb_ci_vat_zero",
+                    "amount": 0,
+                    "start_date": "1973-01-01"
+                }
+            ]
+        }
+    ]
+}

--- a/resources/zone/gb_ci_vat.json
+++ b/resources/zone/gb_ci_vat.json
@@ -1,0 +1,34 @@
+{
+    "name": "United Kingdom - Channel Islands (VAT)",
+    "scope": "tax",
+    "members": [
+        {
+            "type": "country",
+            "id": "gb_ci_vat_0",
+            "name": "Jersey",
+            "country_code": "JE",
+            "included_postal_codes": "\/(^$)|(^JE[0-9]{1})\/"
+        },
+        {
+            "type": "country",
+            "id": "gb_ci_vat_1",
+            "name": "Jersey",
+            "country_code": "GB",
+            "included_postal_codes": "\/(^JE[0-9]{1})\/"
+        },
+        {
+            "type": "country",
+            "id": "gb_ci_vat_2",
+            "name": "Guernsey",
+            "country_code": "GG",
+            "included_postal_codes": "\/(^$)|(^GY[0-9]{1,2})\/"
+        },
+        {
+            "type": "country",
+            "id": "gb_ci_vat_3",
+            "name": "Guernsey",
+            "country_code": "GB",
+            "included_postal_codes": "\/(^GY[0-9]{1,2})\/"
+        }
+    ]
+}

--- a/resources/zone/gb_vat.json
+++ b/resources/zone/gb_vat.json
@@ -5,14 +5,16 @@
         {
             "type": "country",
             "id": "gb_vat_0",
-            "name": "United Kingdom",
-            "country_code": "GB"
+            "name": "United Kingdom (ex. Channel Islands & Isle Of Man)",
+            "country_code": "GB",
+            "excluded_postal_codes": "\/(^IM[0-9]{1})|(^JE[0-9]{1})|(^GY[0-9]{1,2})\/"
         },
         {
             "type": "country",
             "id": "gb_vat_1",
             "name": "Isle of Man",
-            "country_code": "IM"
+            "country_code": "IM",
+            "included_postal_codes": "\/^IM[0-9]{1}\/"
         }
     ]
 }


### PR DESCRIPTION
The UK Channel islands should be treated differently in regards to tax, to the test of the UK.

- Exclude Jersey & Guernsey From UK  for tax purposes. Jersey and Gurney are part of the UK but are no part of the European Union for VAT purposes

- Update United Kingdom to show it excludes channel islands & add exclude regex for IM/JE postcodes

- Add IM postcodes regex