### PR TITLE
Missing imports for documentation and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+trim_trailing_whitespace = true
+insert_final_newline     = true
+end_of_line              = lf
+charset                  = utf-8
+tab_width                = 4
+
+[{*.{awk,bat,c,cpp,d,h,l,re,skl,w32,y},Makefile*}]
+indent_size              = 4
+indent_style             = tab
+
+[*.{dtd,html,inc,php,phpt,rng,wsdl,xml,xsd,xsl}]
+indent_size              = 4
+indent_style             = space
+
+[*.{ac,m4,sh,yml}]
+indent_size              = 2
+indent_style             = space
+
+[*.md]
+indent_style             = space
+max_line_length          = 80
+
+[COMMIT_EDITMSG]
+indent_size              = 4
+indent_style             = space
+max_line_length          = 80
+
+[*.patch]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,34 +1,19 @@
-# https://editorconfig.org/
-
+; top-most EditorConfig file
 root = true
 
+; Unix-style newlines
 [*]
+charset = utf-8
+end_of_line = LF
+insert_final_newline = true
 trim_trailing_whitespace = true
-insert_final_newline     = true
-end_of_line              = lf
-charset                  = utf-8
-tab_width                = 4
 
-[{*.{awk,bat,c,cpp,d,h,l,re,skl,w32,y},Makefile*}]
-indent_size              = 4
-indent_style             = tab
-
-[*.{dtd,html,inc,php,phpt,rng,wsdl,xml,xsd,xsl}]
-indent_size              = 4
-indent_style             = space
-
-[*.{ac,m4,sh,yml}]
-indent_size              = 2
-indent_style             = space
+[*.{php,html,twig}]
+indent_style = space
+indent_size = 4
 
 [*.md]
-indent_style             = space
-max_line_length          = 80
+max_line_length = 80
 
 [COMMIT_EDITMSG]
-indent_size              = 4
-indent_style             = space
-max_line_length          = 80
-
-[*.patch]
-trim_trailing_whitespace = false
+max_line_length = 0

--- a/src/Repository/TaxTypeRepositoryInterface.php
+++ b/src/Repository/TaxTypeRepositoryInterface.php
@@ -2,6 +2,8 @@
 
 namespace CommerceGuys\Tax\Repository;
 
+use CommerceGuys\Tax\Model\TaxTypeInterface;
+
 /**
  * Tax type repository interface.
  */

--- a/src/Resolver/Context.php
+++ b/src/Resolver/Context.php
@@ -45,7 +45,7 @@ class Context
     /**
      * The calculation date.
      *
-     * @var DateTime
+     * @var \DateTime
      */
     protected $date;
 
@@ -162,7 +162,7 @@ class Context
     /**
      * Gets the calculation date.
      *
-     * @return DateTime The calculation date.
+     * @return \DateTime The calculation date.
      */
     public function getDate()
     {

--- a/src/Resolver/TaxResolverInterface.php
+++ b/src/Resolver/TaxResolverInterface.php
@@ -2,6 +2,9 @@
 
 namespace CommerceGuys\Tax\Resolver;
 
+use CommerceGuys\Tax\Model\TaxRateAmountInterface;
+use CommerceGuys\Tax\Model\TaxRateInterface;
+use CommerceGuys\Tax\Model\TaxTypeInterface;
 use CommerceGuys\Tax\TaxableInterface;
 
 /**

--- a/src/Resolver/TaxType/CanadaTaxTypeResolver.php
+++ b/src/Resolver/TaxType/CanadaTaxTypeResolver.php
@@ -2,6 +2,7 @@
 
 namespace CommerceGuys\Tax\Resolver\TaxType;
 
+use CommerceGuys\Tax\Model\TaxTypeInterface;
 use CommerceGuys\Tax\TaxableInterface;
 use CommerceGuys\Tax\Repository\TaxTypeRepositoryInterface;
 use CommerceGuys\Tax\Resolver\Context;

--- a/src/Resolver/TaxType/ChainTaxTypeResolverInterface.php
+++ b/src/Resolver/TaxType/ChainTaxTypeResolverInterface.php
@@ -4,6 +4,7 @@ namespace CommerceGuys\Tax\Resolver\TaxType;
 
 use CommerceGuys\Tax\TaxableInterface;
 use CommerceGuys\Tax\Resolver\Context;
+use CommerceGuys\Tax\Model\TaxTypeInterface;
 use CommerceGuys\Tax\Resolver\TaxType\TaxTypeResolverInterface;
 
 /**

--- a/src/Resolver/TaxType/DefaultTaxTypeResolver.php
+++ b/src/Resolver/TaxType/DefaultTaxTypeResolver.php
@@ -2,6 +2,7 @@
 
 namespace CommerceGuys\Tax\Resolver\TaxType;
 
+use CommerceGuys\Tax\Model\TaxTypeInterface;
 use CommerceGuys\Tax\TaxableInterface;
 use CommerceGuys\Tax\Repository\TaxTypeRepositoryInterface;
 use CommerceGuys\Tax\Resolver\Context;


### PR DESCRIPTION
Was going through your wonderful repo, and noticed some imports missing used in phpdoc. Added them, and also added .editorconfig with the default PHP values (because my editor was doing things it shouldnt)