### PR TITLE
Add tax type for Greek Islands zone so it registers as in the EU

### DIFF
--- a/resources/tax_type/gr_x_vat.json
+++ b/resources/tax_type/gr_x_vat.json
@@ -1,0 +1,45 @@
+{
+    "name": "Greek Islands VAT",
+    "generic_label": "vat",
+    "display_inclusive": true,
+    "zone": "gr_x_vat",
+    "tag": "EU",
+    "rates": [
+        {
+            "id": "gr_x_vat_standard",
+            "name": "Standard",
+            "default": true,
+            "amounts": [
+                {
+                    "id": "gr_x_vat_standard_2016_06",
+                    "amount": 0.17,
+                    "start_date": "2016-06-01"
+                }
+            ]
+        },
+        {
+            "id": "gr_x_vat_intermediate",
+            "name": "Intermediate",
+            "amounts": [
+
+                {
+                    "id": "gr_x_vat_intermediate_2011",
+                    "amount": 0.09,
+                    "start_date": "2011-01-01"
+                }
+            ]
+        },
+        {
+            "id": "gr_x_vat_reduced",
+            "name": "Reduced",
+            "amounts": [
+
+                {
+                    "id": "gr_x_vat_reduced_2015",
+                    "amount": 0.05,
+                    "start_date": "2015-07-01"
+                }
+            ]
+        }
+    ]
+}

--- a/resources/zone/gr_vat.json
+++ b/resources/zone/gr_vat.json
@@ -5,9 +5,9 @@
         {
             "type": "country",
             "id": "gr_vat_0",
-            "name": "Greece (ex. Thassos, Samothrace, Skiros, Northern Sporades, Lesbos, Chios, The Cyclades, The Dodecanese)",
+            "name": "Greece (ex. Lesbos, Chios, Samos, Kos, Leros)",
             "country_code": "GR",
-            "excluded_postal_codes": "\/640 ?04|680 ?02|340 ?07|((370|811|821|840|851) ?[0-9]{2})\/"
+            "excluded_postal_codes": "\/((811|821|831|853|854) ?[0-9]{2})\/"
         }
     ]
 }

--- a/resources/zone/gr_vat.json
+++ b/resources/zone/gr_vat.json
@@ -7,7 +7,7 @@
             "id": "gr_vat_0",
             "name": "Greece (ex. Lesbos, Chios, Samos, Kos, Leros)",
             "country_code": "GR",
-            "excluded_postal_codes": "\/((811|821|831|853|854) ?[0-9]{2})\/"
+            "excluded_postal_codes": "\/(811|821|831|853|854) ?[0-9]{2}\/"
         }
     ]
 }

--- a/resources/zone/gr_x_vat.json
+++ b/resources/zone/gr_x_vat.json
@@ -5,9 +5,9 @@
         {
             "type": "country",
             "id": "gr_x_vat_0",
-            "name": "Thassos, Samothrace, Skiros, Northern Sporades, Lesbos, Chios, The Cyclades, The Dodecanese",
+            "name": "Lesbos, Chios, Samos, Kos, Leros",
             "country_code": "GR",
-            "included_postal_codes": "\/640 ?04|680 ?02|340 ?07|((370|811|821|840|851) ?[0-9]{2})\/"
+            "included_postal_codes": "\/((811|821|831|853|854) ?[0-9]{2})\/"
         }
     ]
 }

--- a/resources/zone/gr_x_vat.json
+++ b/resources/zone/gr_x_vat.json
@@ -7,7 +7,7 @@
             "id": "gr_x_vat_0",
             "name": "Lesbos, Chios, Samos, Kos, Leros",
             "country_code": "GR",
-            "included_postal_codes": "\/((811|821|831|853|854) ?[0-9]{2})\/"
+            "included_postal_codes": "\/(811|821|831|853|854) ?[0-9]{2}\/"
         }
     ]
 }


### PR DESCRIPTION
This addresses two issues.

1. The islands included in the Aegean 30% rate reduction has been reducing over time. It now includes only Lesbos, Chios, Samos, Kos and Leros. I have updated the postcode regex to reflect this [https://en.wikipedia.org/wiki/List_of_postal_codes_in_Greece](Greek postcodes).
2. Not having a tax type and rate data available for a zone causes it not to be included in the EU for under threshold taxation using origin country rates. This means that when fulfilling from the UK I have seen certain parts of Greece not charged GB VAT. See #64 for a similar problem with the Azores.

Unfortunately, I have been unable to find historical data for these tax rates, so I've just used the most recent as I believe they are. [https://news.gtp.gr/2018/12/31/lower-vat-five-greek-islands-extended-six-months/](Extension news)

Also, these Aegean Island rates are meant to have been withdrawn, getting the areas on the same taxation as the rest of Greece but the deadline keeps getting six month extensions. [https://www.avalara.com/vatlive/en/vat-news/greece-extends-five-island-discounted-vat-rates.html](Mention of island rates).

This raises an issue where we won't be able to work out a historical rate because only values change over time rather than zones, but that's an issue for another day.

This relates to #9. Though I wasn't able to find a good source.