### PR TITLE
IE - VAT update 2020/2021

### DIFF
--- a/resources/tax_type/ie_vat.json
+++ b/resources/tax_type/ie_vat.json
@@ -31,7 +31,19 @@
                 {
                     "id": "ie_vat_standard_2012",
                     "amount": 0.23,
-                    "start_date": "2012-01-01"
+                    "start_date": "2012-01-01",
+                    "end_date": "2020-08-31"
+                },
+                {
+                    "id": "ie_vat_standard_2020",
+                    "amount": 0.21,
+                    "start_date": "2020-09-01",
+                    "end_date": "2021-02-28"
+                },
+                {
+                    "id": "ie_vat_standard_2021",
+                    "amount": 0.23,
+                    "start_date": "2021-03-01"
                 }
             ]
         },


### PR DESCRIPTION
https://www.avalara.com/vatlive/en/vat-news/ireland-cuts-vat-from-23--to-21--till-feb-2021.html