### PR TITLE
Remove GB from EU now Brexit transition period is over

### DIFF
--- a/resources/tax_type/gb_vat.json
+++ b/resources/tax_type/gb_vat.json
@@ -3,7 +3,6 @@
     "generic_label": "vat",
     "display_inclusive": true,
     "zone": "gb_vat",
-    "tag": "EU",
     "rates": [
         {
             "id": "gb_vat_standard",


### PR DESCRIPTION
This is a poor approach for now as it loses all of the behaviour around dates, but there isn't an easy fix for that without passing the tax context much further down the chain.