### PR TITLE
Germany has gone back to 19% VAT

### DIFF
--- a/resources/tax_type/de_vat.json
+++ b/resources/tax_type/de_vat.json
@@ -19,7 +19,13 @@
                 {
                     "id": "de_vat_standard_2020",
                     "amount": 0.16,
-                    "start_date": "2020-07-01"
+                    "start_date": "2020-07-01",
+                    "end_date": "2021-01-01"
+                },
+                {
+                    "id": "de_vat_standard_2021",
+                    "amount": 0.19,
+                    "start_date": "2021-01-01"
                 }
             ]
         },

--- a/resources/tax_type/de_vat.json
+++ b/resources/tax_type/de_vat.json
@@ -20,7 +20,7 @@
                     "id": "de_vat_standard_2020",
                     "amount": 0.16,
                     "start_date": "2020-07-01",
-                    "end_date": "2021-01-01"
+                    "end_date": "2020-12-31"
                 },
                 {
                     "id": "de_vat_standard_2021",


### PR DESCRIPTION
the 16% VAT was a temporal COVID-19 reduction and has been reverted back to 19% as off 2021-01-01.