### PR TITLE
Singapore GST 2023

### DIFF
--- a/resources/tax_type/sg_gst.json
+++ b/resources/tax_type/sg_gst.json
@@ -1,26 +1,26 @@
 {
-  "name": "Singaporean GST",
-  "generic_label": "GST",
-  "display_inclusive": true,
-  "zone": "sg_gst",
-  "rates": [
-    {
-      "id": "sg_gst_standard",
-      "name": "Standard",
-      "default": true,
-      "amounts": [
+    "name": "Singaporean GST",
+    "generic_label": "gst",
+    "display_inclusive": true,
+    "zone": "sg_gst",
+    "rates": [
         {
-          "id": "sg_gst_standard_2007",
-          "amount": 0.07,
-          "start_date": "2007-07-01",
-          "end_date": "2022-12-31"
-        },
-        {
-          "id": "sg_gst_standard_2023",
-          "amount": 0.08,
-          "start_date": "2023-01-01"
+            "id": "sg_gst_standard",
+            "name": "Standard",
+            "default": true,
+            "amounts": [
+                {
+                    "id": "sg_gst_standard_2007",
+                    "amount": 0.07,
+                    "end_date": "2022-12-31",
+                    "start_date": "2007-07-01"
+                },
+                {
+                    "id": "sg_gst_standard_2023",
+                    "amount": 0.08,
+                    "start_date": "2023-01-01"
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/resources/tax_type/sg_gst.json
+++ b/resources/tax_type/sg_gst.json
@@ -1,0 +1,26 @@
+{
+  "name": "Singaporean GST",
+  "generic_label": "GST",
+  "display_inclusive": true,
+  "zone": "sg_gst",
+  "rates": [
+    {
+      "id": "sg_gst_standard",
+      "name": "Standard",
+      "default": true,
+      "amounts": [
+        {
+          "id": "sg_gst_standard_2007",
+          "amount": 0.07,
+          "start_date": "2007-07-01",
+          "end_date": "2022-12-31"
+        },
+        {
+          "id": "sg_gst_standard_2023",
+          "amount": 0.08,
+          "start_date": "2023-01-01"
+        }
+      ]
+    }
+  ]
+}

--- a/resources/zone/sg_gst.json
+++ b/resources/zone/sg_gst.json
@@ -1,0 +1,12 @@
+{
+  "name": "Singapore (GST)",
+  "scope": "tax",
+  "members": [
+    {
+      "type": "country",
+      "id": "sg_gst_0",
+      "name": "Singapore",
+      "country_code": "SG"
+    }
+  ]
+}

--- a/resources/zone/sg_gst.json
+++ b/resources/zone/sg_gst.json
@@ -1,12 +1,12 @@
 {
-  "name": "Singapore (GST)",
-  "scope": "tax",
-  "members": [
-    {
-      "type": "country",
-      "id": "sg_gst_0",
-      "name": "Singapore",
-      "country_code": "SG"
-    }
-  ]
+    "name": "Singapore (GST)",
+    "scope": "tax",
+    "members": [
+        {
+            "type": "country",
+            "id": "sg_gst_0",
+            "name": "Singapore",
+            "country_code": "SG"
+        }
+    ]
 }


### PR DESCRIPTION
On January 1, 2023, Singapore GST to be extended to imported low-value goods.
This PR adds the necessary files to resources/tax_type and resources/zone

Current 7% rate is included to aid testing in advance