### PR TITLE
Adds the 2023 LU taxes

### DIFF
--- a/resources/tax_type/lu_vat.json
+++ b/resources/tax_type/lu_vat.json
@@ -19,7 +19,13 @@
                 {
                     "id": "lu_vat_standard_2015",
                     "amount": 0.17,
-                    "start_date": "2015-01-01"
+                    "start_date": "2015-01-01",
+                    "end_date": "2022-12-31"
+                },
+                {
+                    "id": "lu_vat_standard_2023",
+                    "amount": 0.16,
+                    "start_date": "2023-01-01"
                 }
             ]
         },
@@ -36,7 +42,13 @@
                 {
                     "id": "lu_vat_intermediate_2015",
                     "amount": 0.14,
-                    "start_date": "2015-01-01"
+                    "start_date": "2015-01-01",
+                    "end_date": "2022-12-31"
+                },
+                {
+                    "id": "lu_vat_intermediate_2023",
+                    "amount": 0.13,
+                    "start_date": "2023-01-01"
                 }
             ]
         },
@@ -53,7 +65,13 @@
                 {
                     "id": "lu_vat_reduced_2015",
                     "amount": 0.08,
-                    "start_date": "2015-01-01"
+                    "start_date": "2015-01-01",
+                    "end_date": "2022-12-31"
+                },
+                {
+                    "id": "lu_vat_reduced_2023",
+                    "amount": 0.07,
+                    "start_date": "2023-01-01"
                 }
             ]
         },


### PR DESCRIPTION
Adds the taxes for LU that are valid since 2023-01-01 according to https://pfi.public.lu/fr/professionnel/tva/taxe-valeur-ajoutee/taux-nationaux-applicables.html