### PR TITLE
Add Singapore GST rate change for 2024

### DIFF
--- a/resources/tax_type/sg_gst.json
+++ b/resources/tax_type/sg_gst.json
@@ -18,7 +18,13 @@
                 {
                     "id": "sg_gst_standard_2023",
                     "amount": 0.08,
-                    "start_date": "2023-01-01"
+                    "start_date": "2023-01-01",
+                    "end_date": "2023-12-31"
+                },
+                {
+                    "id": "sg_gst_standard_2024",
+                    "amount": 0.09,
+                    "start_date": "2024-01-01"
                 }
             ]
         }


### PR DESCRIPTION
Reference for change: https://www.globalvatcompliance.com/globalvatnews/singapore-gst-increase-2024/

Simple change from 8% to 9%