### PR TITLE
Update Romanian VAT rates for August 2025

### DIFF
--- a/resources/tax_type/ro_vat.json
+++ b/resources/tax_type/ro_vat.json
@@ -31,7 +31,13 @@
                 {
                     "id": "ro_vat_standard_2017",
                     "amount": 0.19,
-                    "start_date": "2017-01-01"
+                    "start_date": "2017-01-01",
+                    "end_date": "2025-07-31"
+                },
+                {
+                    "id": "ro_vat_standard_2025",
+                    "amount": 0.21,
+                    "start_date": "2025-08-01"
                 }
             ]
         },
@@ -42,7 +48,8 @@
                 {
                     "id": "ro_vat_intermediate_2008",
                     "amount": 0.09,
-                    "start_date": "2008-12-01"
+                    "start_date": "2008-12-01",
+                    "end_date": "2025-07-31"
                 }
             ]
         },
@@ -53,7 +60,20 @@
                 {
                     "id": "ro_vat_reduced_2008",
                     "amount": 0.05,
-                    "start_date": "2008-12-01"
+                    "start_date": "2008-12-01",
+                    "end_date": "2025-07-31"
+                }
+            ]
+        },
+        {
+            "id": "ro_vat_reduced_2025",
+            "name": "Reduced",
+            "default": false,
+            "amounts": [
+                {
+                    "id": "ro_vat_reduced_2025_amount",
+                    "amount": 0.11,
+                    "start_date": "2025-08-01"
                 }
             ]
         }


### PR DESCRIPTION
Romania increased the standard VAT rate from 19% to 21% effective 1 August 2025 (Law No. 141/2025). The existing 5% and 9% reduced rates were simultaneously abolished and replaced by a single 11% reduced rate.

Sources:
[https://www.ey.com/en_gl/technical/tax-alerts/romanian-tax-changes-introduced-by-new-fiscal-and-budgetary-measures
https://marosavat.com/vat-news/romanian-vat-rate-changes](url)

[https://www.ey.com/en_gl/technical/tax-alerts/romanian-tax-changes-introduced-by-new-fiscal-and-budgetary-measures
https://marosavat.com/vat-news/romanian-vat-rate-changes](url)