### PR TITLE
Explict null params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 .phpunit.result.cache
+.idea

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ tax
 
 [![Build Status](https://travis-ci.org/commerceguys/tax.svg?branch=master)](https://travis-ci.org/commerceguys/tax)
 
-A PHP 5.5+ tax management library.
+A PHP 7.1+ tax management library.
 
 Features:
 - Smart data model designed for fluctuating tax rate amounts ("19% -> 21% on January 1st")

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["tax", "vat"],
     "license": "MIT",
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.1",
         "commerceguys/addressing": "^1.0",
         "commerceguys/zone": "^0.8",
         "doctrine/collections": "^1.0 || ^2.0"

--- a/src/Model/TaxRate.php
+++ b/src/Model/TaxRate.php
@@ -76,7 +76,7 @@ class TaxRate implements TaxRateEntityInterface
     /**
      * {@inheritdoc}
      */
-    public function setType(TaxTypeEntityInterface $type = null)
+    public function setType(?TaxTypeEntityInterface $type = null)
     {
         $this->type = $type;
 
@@ -166,7 +166,7 @@ class TaxRate implements TaxRateEntityInterface
     /**
      * {@inheritdoc}
      */
-    public function getAmount(\DateTime $date = null)
+    public function getAmount(?\DateTime $date = null)
     {
         if (is_null($date)) {
             // Initialize DateTime to the current date.

--- a/src/Model/TaxRateAmount.php
+++ b/src/Model/TaxRateAmount.php
@@ -55,7 +55,7 @@ class TaxRateAmount implements TaxRateAmountEntityInterface
     /**
      * {@inheritdoc}
      */
-    public function setRate(TaxRateEntityInterface $rate = null)
+    public function setRate(?TaxRateEntityInterface $rate = null)
     {
         $this->rate = $rate;
 

--- a/src/Model/TaxRateAmountEntityInterface.php
+++ b/src/Model/TaxRateAmountEntityInterface.php
@@ -11,7 +11,7 @@ interface TaxRateAmountEntityInterface extends TaxRateAmountInterface
      *
      * @return self
      */
-    public function setRate(TaxRateEntityInterface $rate = null);
+    public function setRate(?TaxRateEntityInterface $rate = null);
 
     /**
      * Sets the tax rate amount id.

--- a/src/Model/TaxRateEntityInterface.php
+++ b/src/Model/TaxRateEntityInterface.php
@@ -13,7 +13,7 @@ interface TaxRateEntityInterface extends TaxRateInterface
      *
      * @return self
      */
-    public function setType(TaxTypeEntityInterface $type = null);
+    public function setType(?TaxTypeEntityInterface $type = null);
 
     /**
      * Sets the tax rate id.

--- a/src/Repository/TaxTypeRepository.php
+++ b/src/Repository/TaxTypeRepository.php
@@ -48,7 +48,7 @@ class TaxTypeRepository implements TaxTypeRepositoryInterface
      * @param string $definitionPath The path to the tax type and zone
      *                               definitions. Defaults to 'resources/'.
      */
-    public function __construct($definitionPath = null, ZoneRepositoryInterface $zoneRepository = null)
+    public function __construct($definitionPath = null, ?ZoneRepositoryInterface $zoneRepository = null)
     {
         $definitionPath = $definitionPath ?: __DIR__ . '/../../resources/';
         $this->definitionPath = $definitionPath . 'tax_type/';

--- a/src/Resolver/Context.php
+++ b/src/Resolver/Context.php
@@ -58,8 +58,13 @@ class Context
      * @param array             $storeRegistrations
      * @param \DateTime         $date
      */
-    public function __construct(AddressInterface $customerAddress, AddressInterface $storeAddress, $customerTaxNumber = '', array $storeRegistrations = [], \DateTime $date = null)
-    {
+    public function __construct(
+        AddressInterface $customerAddress,
+        AddressInterface $storeAddress,
+        $customerTaxNumber = '',
+        array $storeRegistrations = [],
+        ?\DateTime $date = null
+    ) {
         $this->customerAddress = $customerAddress;
         $this->storeAddress = $storeAddress;
         $this->customerTaxNumber = $customerTaxNumber;


### PR DESCRIPTION
Fix some deprecated warnings for PHP8.4 - had to bump min req to 7.1 to add the null type hint.

https://github.com/commerceguys/zone is throwing 2 but is archived 😢... but now have https://github.com/commerceguys/tax/pull/106 in the works.