### PR TITLE
Kill commerceguys/zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Features:
 - Predefined tax rates for EU countries and Switzerland. More to come.
 - Tax resolvers with logic for all major use cases.
 
-Requires [commerceguys/zone](https://github.com/commerceguys/zone).
+Requires [commerceguys/addressing](https://github.com/commerceguys/addressing).
 
 The backstory behind the library design can be found in [this blog post](https://drupalcommerce.org/blog/31036/commerce-2x-stories-taxes).
 
@@ -18,7 +18,7 @@ Don't see your country's tax types and rates in the dataset? Send us a PR!
 
 # Data model
 
-[Zone](https://github.com/commerceguys/zone/blob/master/src/Model/ZoneInterface.php) 1-1 [TaxType](https://github.com/commerceguys/tax/blob/master/src/Model/TaxTypeInterface.php) 1-n [TaxRate](https://github.com/commerceguys/tax/blob/master/src/Model/TaxRateInterface.php) 1-n [TaxRateAmount](https://github.com/commerceguys/tax/blob/master/src/Model/TaxRateAmountInterface.php)
+[Zone](https://github.com/commerceguys/addressing/blob/main/src/Zone/Zone.php) 1-1 [TaxType](https://github.com/commerceguys/tax/blob/master/src/Model/TaxTypeInterface.php) 1-n [TaxRate](https://github.com/commerceguys/tax/blob/master/src/Model/TaxRateInterface.php) 1-n [TaxRateAmount](https://github.com/commerceguys/tax/blob/master/src/Model/TaxRateAmountInterface.php)
 
 Each tax type has a zone and one or more tax rates.
 Each tax rate has one or more tax rate amounts.
@@ -110,7 +110,6 @@ $amounts = $resolver->resolveAmounts($taxable, $context);
 // More rarely, if only the types or rates are needed:
 $rates = $resolver->resolveRates($taxable, $context);
 $types = $resolver->resolveTypes($taxable, $context);
-
 ```
 
 # Credits

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "require": {
         "php": ">=7.1",
         "commerceguys/addressing": "^1.0",
-        "commerceguys/zone": "^0.8",
         "doctrine/collections": "^1.0 || ^2.0"
     },
     "require-dev": {

--- a/resources/zone/at_vat.json
+++ b/resources/zone/at_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Austria (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/au_gst.json
+++ b/resources/zone/au_gst.json
@@ -1,6 +1,5 @@
 {
     "name": "Australia (GST)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/be_vat.json
+++ b/resources/zone/be_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Belgium (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/bg_vat.json
+++ b/resources/zone/bg_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Bulgaria (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/ch_vat.json
+++ b/resources/zone/ch_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Switzerland (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/cy_vat.json
+++ b/resources/zone/cy_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Cyprus (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/cz_vat.json
+++ b/resources/zone/cz_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Czech Republic (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/de_vat.json
+++ b/resources/zone/de_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Germany (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/dk_vat.json
+++ b/resources/zone/dk_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Denmark (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/ee_vat.json
+++ b/resources/zone/ee_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Estonia (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/es_vat.json
+++ b/resources/zone/es_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Spain (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/eu_vat.json
+++ b/resources/zone/eu_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "EU (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "zone",

--- a/resources/zone/fi_vat.json
+++ b/resources/zone/fi_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Finland (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/fr_h_vat.json
+++ b/resources/zone/fr_h_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "France - Corsica (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/fr_vat.json
+++ b/resources/zone/fr_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "France (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/fr_x_vat.json
+++ b/resources/zone/fr_x_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "France DOM (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/gb_vat.json
+++ b/resources/zone/gb_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "United Kingdom (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/gr_vat.json
+++ b/resources/zone/gr_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Greece (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/gr_x_vat.json
+++ b/resources/zone/gr_x_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Greece Islands (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/hr_vat.json
+++ b/resources/zone/hr_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Croatia (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/hu_vat.json
+++ b/resources/zone/hu_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Hungary (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/id_gst.json
+++ b/resources/zone/id_gst.json
@@ -1,6 +1,5 @@
 {
     "name": "Indonesia (GST)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/ie_vat.json
+++ b/resources/zone/ie_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Ireland (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/is_vat.json
+++ b/resources/zone/is_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Iceland (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/it_vat.json
+++ b/resources/zone/it_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Italy (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/lt_vat.json
+++ b/resources/zone/lt_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Lithuania (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/lu_vat.json
+++ b/resources/zone/lu_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Luxembourg (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/lv_vat.json
+++ b/resources/zone/lv_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Latvia (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/mt_vat.json
+++ b/resources/zone/mt_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Malta (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/nl_vat.json
+++ b/resources/zone/nl_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Netherlands (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/no_vat.json
+++ b/resources/zone/no_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Norway (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/nz_gst.json
+++ b/resources/zone/nz_gst.json
@@ -1,6 +1,5 @@
 {
     "name": "New Zealand (GST)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/pl_vat.json
+++ b/resources/zone/pl_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Poland (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/pt_20_vat.json
+++ b/resources/zone/pt_20_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Portugal - Azores (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/pt_30_vat.json
+++ b/resources/zone/pt_30_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Portugal - Madeira (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/pt_vat.json
+++ b/resources/zone/pt_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Portugal (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/ro_vat.json
+++ b/resources/zone/ro_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Romania (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/se_vat.json
+++ b/resources/zone/se_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Sweden (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/sg_gst.json
+++ b/resources/zone/sg_gst.json
@@ -1,6 +1,5 @@
 {
     "name": "Singapore (GST)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/si_vat.json
+++ b/resources/zone/si_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Slovenia (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/sk_vat.json
+++ b/resources/zone/sk_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "Slovakia (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/resources/zone/za_vat.json
+++ b/resources/zone/za_vat.json
@@ -1,6 +1,5 @@
 {
     "name": "South Africa (VAT)",
-    "scope": "tax",
     "members": [
         {
             "type": "country",

--- a/src/Exception/UnknownZoneException.php
+++ b/src/Exception/UnknownZoneException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommerceGuys\Tax\Exception;
+
+/**
+ * Thrown when an unknown zone id is passed to the ZoneRepository.
+ */
+class UnknownZoneException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Model/TaxType.php
+++ b/src/Model/TaxType.php
@@ -2,8 +2,8 @@
 
 namespace CommerceGuys\Tax\Model;
 
+use CommerceGuys\Addressing\Zone\Zone;
 use CommerceGuys\Tax\Enum\GenericLabel;
-use CommerceGuys\Zone\Model\ZoneEntityInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
@@ -59,7 +59,7 @@ class TaxType implements TaxTypeEntityInterface
     /**
      * The tax type zone.
      *
-     * @var ZoneEntityInterface
+     * @var Zone
      */
     protected $zone;
 
@@ -216,7 +216,7 @@ class TaxType implements TaxTypeEntityInterface
     /**
      * {@inheritdoc}
      */
-    public function setZone(ZoneEntityInterface $zone)
+    public function setZone(Zone $zone)
     {
         $this->zone = $zone;
 

--- a/src/Model/TaxTypeEntityInterface.php
+++ b/src/Model/TaxTypeEntityInterface.php
@@ -2,8 +2,8 @@
 
 namespace CommerceGuys\Tax\Model;
 
+use CommerceGuys\Addressing\Zone\Zone;
 use Doctrine\Common\Collections\Collection;
-use CommerceGuys\Zone\Model\ZoneEntityInterface;
 
 interface TaxTypeEntityInterface extends TaxTypeInterface
 {
@@ -62,11 +62,11 @@ interface TaxTypeEntityInterface extends TaxTypeInterface
     /**
      * Sets the tax type zone.
      *
-     * @param ZoneEntityInterface $zone The tax type zone.
+     * @param Zone $zone The tax type zone.
      *
      * @return self
      */
-    public function setZone(ZoneEntityInterface $zone);
+    public function setZone(Zone $zone);
 
     /**
      * Sets the tax type tag.

--- a/src/Model/TaxTypeInterface.php
+++ b/src/Model/TaxTypeInterface.php
@@ -2,7 +2,7 @@
 
 namespace CommerceGuys\Tax\Model;
 
-use CommerceGuys\Zone\Model\ZoneInterface;
+use CommerceGuys\Addressing\Zone\Zone;
 
 interface TaxTypeInterface
 {
@@ -71,7 +71,7 @@ interface TaxTypeInterface
     /**
      * Gets the tax type zone.
      *
-     * @return ZoneInterface The tax type zone.
+     * @return Zone The tax type zone.
      */
     public function getZone();
 

--- a/src/Repository/TaxTypeRepository.php
+++ b/src/Repository/TaxTypeRepository.php
@@ -6,8 +6,6 @@ use CommerceGuys\Tax\Exception\UnknownTaxTypeException;
 use CommerceGuys\Tax\Model\TaxType;
 use CommerceGuys\Tax\Model\TaxRate;
 use CommerceGuys\Tax\Model\TaxRateAmount;
-use CommerceGuys\Zone\Repository\ZoneRepository;
-use CommerceGuys\Zone\Repository\ZoneRepositoryInterface;
 
 /**
  * Manages tax types based on JSON definitions.
@@ -24,7 +22,7 @@ class TaxTypeRepository implements TaxTypeRepositoryInterface
     /**
      * The zone repository.
      *
-     * @var ZoneRepositoryInterface
+     * @var ZoneRepository
      */
     protected $zoneRepository;
 
@@ -48,7 +46,7 @@ class TaxTypeRepository implements TaxTypeRepositoryInterface
      * @param string $definitionPath The path to the tax type and zone
      *                               definitions. Defaults to 'resources/'.
      */
-    public function __construct($definitionPath = null, ?ZoneRepositoryInterface $zoneRepository = null)
+    public function __construct($definitionPath = null, ?ZoneRepository $zoneRepository = null)
     {
         $definitionPath = $definitionPath ?: __DIR__ . '/../../resources/';
         $this->definitionPath = $definitionPath . 'tax_type/';

--- a/src/Repository/ZoneRepository.php
+++ b/src/Repository/ZoneRepository.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommerceGuys\Tax\Repository;
+
+use CommerceGuys\Addressing\Zone\Zone;
+use CommerceGuys\Tax\Exception\UnknownZoneException;
+
+/**
+ * Manages zones based on JSON definitions.
+ */
+class ZoneRepository
+{
+    /**
+     * The path where zone definitions are stored.
+     *
+     * @var string
+     */
+    protected $definitionPath;
+
+    /**
+     * Zone index.
+     *
+     * @var array
+     */
+    protected $zoneIndex = [];
+
+    /**
+     * Zones.
+     *
+     * @var Zone[]
+     */
+    protected $zones = [];
+
+    /**
+     * Creates a ZoneRepository instance.
+     *
+     * @param string $definitionPath Path to the zone definitions.
+     */
+    public function __construct(string $definitionPath)
+    {
+        $this->definitionPath = $definitionPath;
+    }
+
+    public function get(string $id): Zone
+    {
+        if (!isset($this->zones[$id])) {
+            $definition = $this->loadDefinition($id);
+            $this->zones[$id] = $this->createZoneFromDefinition($definition);
+        }
+
+        return $this->zones[$id];
+    }
+
+    public function getAll(): array
+    {
+        // Build the list of all available zones.
+        if (empty($this->zoneIndex)) {
+            if ($handle = opendir($this->definitionPath)) {
+                while (false !== ($entry = readdir($handle))) {
+                    if (substr($entry, 0, 1) != '.') {
+                        $id = strtok($entry, '.');
+                        $this->zoneIndex[] = $id;
+                    }
+                }
+                closedir($handle);
+            }
+        }
+
+        $zones = [];
+        foreach ($this->zoneIndex as $id) {
+            $zones[$id] = $this->get($id);
+        }
+
+        return $zones;
+    }
+
+    /**
+     * Loads the zone definition for the provided id.
+     *
+     * @param string $id The zone id.
+     * @return array The zone definition.
+     */
+    protected function loadDefinition(string $id): array
+    {
+        $filename = $this->definitionPath . $id . '.json';
+        $definition = @file_get_contents($filename);
+        if (empty($definition)) {
+            throw new UnknownZoneException($id);
+        }
+        $definition = json_decode($definition, true);
+        $definition['id'] = $id;
+
+        return $definition;
+    }
+
+    /**
+     * Creates a Zone instance from the provided definition.
+     *
+     * @param array $definition The zone definition.
+     * @return Zone
+     */
+    protected function createZoneFromDefinition(array $definition): Zone
+    {
+        $definition['label'] = $definition['name'];
+
+        $territories = [];
+        foreach ($definition['members'] as $member) {
+            if ($member['type'] === 'zone') {
+                foreach ($this->loadDefinition($member['zone'])['members'] as $otherTerritory) {
+                    $territories[] = $otherTerritory;
+                }
+            } else {
+                $territories[] = $member;
+            }
+        }
+        $definition['territories'] = $territories;
+        return new Zone($definition);
+    }
+}

--- a/src/Resolver/TaxType/StoreRegistrationCheckerTrait.php
+++ b/src/Resolver/TaxType/StoreRegistrationCheckerTrait.php
@@ -3,9 +3,9 @@
 namespace CommerceGuys\Tax\Resolver\TaxType;
 
 use CommerceGuys\Addressing\Address;
+use CommerceGuys\Addressing\Zone\Zone;
 use CommerceGuys\Tax\Model\TaxTypeInterface;
 use CommerceGuys\Tax\Resolver\Context;
-use CommerceGuys\Zone\Model\ZoneInterface;
 
 trait StoreRegistrationCheckerTrait
 {
@@ -19,13 +19,13 @@ trait StoreRegistrationCheckerTrait
     /**
      * Checks whether the store is registered to collect taxes in the given zone.
      *
-     * @param ZoneInterface $zone    The zone.
+     * @param Zone $zone    The zone.
      * @param Context       $context The context containing store information.
      *
      * @return bool True if the store is registered to collect taxes in the
      *              given zone, false otherwise.
      */
-    protected function checkStoreRegistration(ZoneInterface $zone, Context $context)
+    protected function checkStoreRegistration(Zone $zone, Context $context)
     {
         $storeRegistrations = $context->getStoreRegistrations();
         foreach ($storeRegistrations as $country) {

--- a/tests/Model/TaxTypeTest.php
+++ b/tests/Model/TaxTypeTest.php
@@ -105,7 +105,8 @@ class TaxTypeTest extends TestCase
     public function testZone()
     {
         $zone = $this
-            ->getMockBuilder('CommerceGuys\Zone\Model\Zone')
+            ->getMockBuilder('CommerceGuys\Addressing\Zone\Zone')
+            ->setConstructorArgs([['id' => 'test', 'label' => 'test label', 'territories' => [['country_code' => 'test']]]])
             ->getMock();
 
         $this->taxType->setZone($zone);

--- a/tests/Repository/TaxTypeRepositoryTest.php
+++ b/tests/Repository/TaxTypeRepositoryTest.php
@@ -4,6 +4,7 @@ namespace CommerceGuys\Tax\Tests\Repository;
 
 use CommerceGuys\Tax\Enum\GenericLabel;
 use CommerceGuys\Tax\Repository\TaxTypeRepository;
+use CommerceGuys\Tax\Repository\ZoneRepository;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 
@@ -109,7 +110,7 @@ class TaxTypeRepositoryTest extends TestCase
     {
         $taxType = $this->taxTypeRepository->get('fr_vat');
         $this->assertInstanceOf('CommerceGuys\Tax\Model\TaxType', $taxType);
-        $this->assertInstanceOf('CommerceGuys\Zone\Model\Zone', $taxType->getZone());
+        $this->assertInstanceOf('CommerceGuys\Addressing\Zone\Zone', $taxType->getZone());
         $this->assertEquals('fr_vat', $taxType->getId());
         $this->assertEquals('French VAT', $taxType->getName());
         $this->assertEquals(GenericLabel::VAT, $taxType->getGenericLabel());
@@ -178,13 +179,13 @@ class TaxTypeRepositoryTest extends TestCase
     /**
      * Returns a mock zone repository.
      *
-     * @return \CommerceGuys\Zone\Repository\ZoneRepository
+     * @return \CommerceGuys\Tax\Repository\ZoneRepository
      */
-    protected function getZoneRepository()
+    protected function getZoneRepository(): ZoneRepository
     {
-        $zone = $this->createMock('CommerceGuys\Zone\Model\Zone');
+        $zone = $this->createMock('CommerceGuys\Addressing\Zone\Zone');
         $zoneRepository = $this
-            ->getMockBuilder('CommerceGuys\Zone\Repository\ZoneRepository')
+            ->getMockBuilder('CommerceGuys\Tax\Repository\ZoneRepository')
             ->disableOriginalConstructor()
             ->getMock();
         $zoneRepository

--- a/tests/Repository/ZoneRepositoryTest.php
+++ b/tests/Repository/ZoneRepositoryTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommerceGuys\Tax\Tests\Repository;
+
+use CommerceGuys\Tax\Repository\ZoneRepository;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \CommerceGuys\Tax\Repository\ZoneRepository
+ */
+final class ZoneRepositoryTest extends TestCase
+{
+    /**
+     * Known zones.
+     *
+     * @var array
+     */
+    protected $zones = [
+        'de_vat' => [
+            'name' => 'Germany (VAT)',
+            'members' => [
+                [
+                    'type' => 'country',
+                    'country_code' => 'DE',
+                ],
+                [
+                    'type' => 'country',
+                    'country_code' => 'AT',
+                    'included_postal_codes' => '6691, 6991:6993',
+                    'administrative_area' => 'dummyArea',
+                    'locality' => 'dummyLocality',
+                    'dependent_locality' => 'dummyDependentLocality',
+                    'excluded_postal_codes' => '123456ExPostcodes',
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * @covers ::__construct
+     */
+    public function testConstructor(): ZoneRepository
+    {
+        // Mock the existence of JSON definitions on the filesystem.
+        $root = vfsStream::setup('resources');
+        $directory = vfsStream::newDirectory('zone')->at($root);
+        foreach ($this->zones as $id => $definition) {
+            $filename = $id . '.json';
+            vfsStream::newFile($filename)->at($directory)->setContent(json_encode($definition));
+        }
+
+        // Instantiate the zone repository and confirm that the
+        // definition path was properly set.
+        $zoneRepository = new ZoneRepository('vfs://resources/zone/');
+        $definitionPath = $this->getObjectAttribute($zoneRepository, 'definitionPath');
+        $this->assertEquals('vfs://resources/zone/', $definitionPath);
+
+        return $zoneRepository;
+    }
+
+    /**
+     * @covers ::get
+     * @covers ::loadDefinition
+     * @covers ::createZoneFromDefinition
+     *
+     * @uses \CommerceGuys\Addressing\Zone\Zone
+     * @uses \CommerceGuys\Addressing\Zone\ZoneTerritory
+     * @uses \CommerceGuys\Addressing\PostalCodeHelper
+     * @depends testConstructor
+     */
+    public function testGet(ZoneRepository $zoneRepository): void
+    {
+        $zone = $zoneRepository->get('de_vat');
+        $this->assertInstanceOf('CommerceGuys\Addressing\Zone\Zone', $zone);
+        $this->assertEquals('de_vat', $zone->getId());
+        $this->assertEquals('Germany (VAT)', $zone->getLabel());
+        $territories = $zone->getTerritories();
+        $this->assertCount(2, $territories);
+
+        $germanyTerritory = $territories[0];
+        $this->assertInstanceOf('CommerceGuys\Addressing\Zone\ZoneTerritory', $germanyTerritory);
+        $this->assertEquals('DE', $germanyTerritory->getCountryCode());
+
+        $austriaTerritory = $territories[1];
+        $this->assertInstanceOf('CommerceGuys\Addressing\Zone\ZoneTerritory', $austriaTerritory);
+        $this->assertEquals('AT', $austriaTerritory->getCountryCode());
+        $this->assertEquals('6691, 6991:6993', $austriaTerritory->getIncludedPostalCodes());
+        $this->assertEquals('123456ExPostcodes', $austriaTerritory->getExcludedPostalCodes());
+        $this->assertEquals('dummyArea', $austriaTerritory->getAdministrativeArea());
+        $this->assertEquals('dummyLocality', $austriaTerritory->getLocality());
+        $this->assertEquals('dummyDependentLocality', $austriaTerritory->getDependentLocality());
+
+        // Test the static cache.
+        $sameZone = $zoneRepository->get('de_vat');
+        $this->assertSame($zone, $sameZone);
+    }
+
+    /**
+     * @covers ::get
+     * @covers ::loadDefinition
+     * @covers ::createZoneFromDefinition
+     * @depends testConstructor
+     */
+    public function testGetNonExistingZone(ZoneRepository $zoneRepository): void
+    {
+        $this->expectException(\CommerceGuys\Tax\Exception\UnknownZoneException::class);
+        $zone = $zoneRepository->get('fr_vat');
+    }
+
+    /**
+     * @covers ::getAll
+     * @covers ::loadDefinition
+     * @covers ::createZoneFromDefinition
+     *
+     * @uses \CommerceGuys\Tax\Repository\ZoneRepository::get
+     * @uses \CommerceGuys\Addressing\Zone\Zone
+     * @uses \CommerceGuys\Addressing\Zone\ZoneTerritory
+     * @uses \CommerceGuys\Addressing\PostalCodeHelper
+     * @depends testConstructor
+     */
+    public function testGetAll(ZoneRepository $zoneRepository): void
+    {
+        $zones = $zoneRepository->getAll();
+        $this->assertCount(1, $zones);
+        $this->assertArrayHasKey('de_vat', $zones);
+        $this->assertEquals($zones['de_vat']->getId(), 'de_vat');
+    }
+}

--- a/tests/Resolver/TaxRate/DefaultTaxRateResolverTest.php
+++ b/tests/Resolver/TaxRate/DefaultTaxRateResolverTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\TestCase;
  */
 class DefaultTaxRateResolverTest extends TestCase
 {
+    private $resolver = null;
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
`commerceguys/zone` is dead, As zone stuff is in `commerceguys/addressing` - the only thing missing is the Repository, I have added here now.

Closes https://github.com/commerceguys/tax/issues/101.

Likely this is a breaking change release as the type/class for Zone is different if usage has custom resolvers or repositories.