### PR TITLE
Kill commerceguys/zone & commerceguys/addressing upgrade

### DIFF
--- a/.github/workflows/phpci.yml
+++ b/.github/workflows/phpci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
       fail-fast: false
     name: CI PHP ${{ matrix.php-versions }}
 
@@ -24,7 +24,6 @@ jobs:
           php_version: ${{ matrix.php-versions }}
 
       - name: PHPUnit Tests
-        uses: php-actions/phpunit@v3
+        uses: php-actions/phpunit@v4
         with:
-          version: "8"
           php_version: ${{ matrix.php-versions }}

--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,12 @@
     "keywords": ["tax", "vat"],
     "license": "MIT",
     "require": {
-        "php": ">=7.1",
-        "commerceguys/addressing": "^1.0",
+        "php": ">=7.4",
+        "commerceguys/addressing": "^1.0 || ^2.0",
         "doctrine/collections": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^9.0",
         "mikey179/vfsstream": "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "require": {
         "php": ">=7.1",
         "commerceguys/addressing": "^1.0",
-        "commerceguys/zone": "^0.8",
         "doctrine/collections": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {

--- a/src/Model/TaxType.php
+++ b/src/Model/TaxType.php
@@ -2,8 +2,8 @@
 
 namespace CommerceGuys\Tax\Model;
 
+use CommerceGuys\Addressing\Zone\Zone;
 use CommerceGuys\Tax\Enum\GenericLabel;
-use CommerceGuys\Zone\Model\ZoneEntityInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
@@ -59,7 +59,7 @@ class TaxType implements TaxTypeEntityInterface
     /**
      * The tax type zone.
      *
-     * @var ZoneEntityInterface
+     * @var Zone
      */
     protected $zone;
 
@@ -216,7 +216,7 @@ class TaxType implements TaxTypeEntityInterface
     /**
      * {@inheritdoc}
      */
-    public function setZone(ZoneEntityInterface $zone)
+    public function setZone(Zone $zone)
     {
         $this->zone = $zone;
 

--- a/src/Model/TaxTypeEntityInterface.php
+++ b/src/Model/TaxTypeEntityInterface.php
@@ -2,8 +2,8 @@
 
 namespace CommerceGuys\Tax\Model;
 
+use CommerceGuys\Addressing\Zone\Zone;
 use Doctrine\Common\Collections\Collection;
-use CommerceGuys\Zone\Model\ZoneEntityInterface;
 
 interface TaxTypeEntityInterface extends TaxTypeInterface
 {
@@ -62,11 +62,11 @@ interface TaxTypeEntityInterface extends TaxTypeInterface
     /**
      * Sets the tax type zone.
      *
-     * @param ZoneEntityInterface $zone The tax type zone.
+     * @param Zone $zone The tax type zone.
      *
      * @return self
      */
-    public function setZone(ZoneEntityInterface $zone);
+    public function setZone(Zone $zone);
 
     /**
      * Sets the tax type tag.

--- a/src/Model/TaxTypeInterface.php
+++ b/src/Model/TaxTypeInterface.php
@@ -2,7 +2,7 @@
 
 namespace CommerceGuys\Tax\Model;
 
-use CommerceGuys\Zone\Model\ZoneInterface;
+use CommerceGuys\Addressing\Zone\Zone;
 
 interface TaxTypeInterface
 {
@@ -71,7 +71,7 @@ interface TaxTypeInterface
     /**
      * Gets the tax type zone.
      *
-     * @return ZoneInterface The tax type zone.
+     * @return Zone The tax type zone.
      */
     public function getZone();
 

--- a/src/Repository/TaxTypeRepository.php
+++ b/src/Repository/TaxTypeRepository.php
@@ -6,8 +6,6 @@ use CommerceGuys\Tax\Exception\UnknownTaxTypeException;
 use CommerceGuys\Tax\Model\TaxType;
 use CommerceGuys\Tax\Model\TaxRate;
 use CommerceGuys\Tax\Model\TaxRateAmount;
-use CommerceGuys\Zone\Repository\ZoneRepository;
-use CommerceGuys\Zone\Repository\ZoneRepositoryInterface;
 
 /**
  * Manages tax types based on JSON definitions.
@@ -24,7 +22,7 @@ class TaxTypeRepository implements TaxTypeRepositoryInterface
     /**
      * The zone repository.
      *
-     * @var ZoneRepositoryInterface
+     * @var ZoneRepository
      */
     protected $zoneRepository;
 
@@ -48,7 +46,7 @@ class TaxTypeRepository implements TaxTypeRepositoryInterface
      * @param string $definitionPath The path to the tax type and zone
      *                               definitions. Defaults to 'resources/'.
      */
-    public function __construct($definitionPath = null, ?ZoneRepositoryInterface $zoneRepository = null)
+    public function __construct($definitionPath = null, ?ZoneRepository $zoneRepository = null)
     {
         $definitionPath = $definitionPath ?: __DIR__ . '/../../resources/';
         $this->definitionPath = $definitionPath . 'tax_type/';

--- a/src/Repository/ZoneRepository.php
+++ b/src/Repository/ZoneRepository.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommerceGuys\Tax\Repository;
+
+use CommerceGuys\Addressing\Zone\Zone;
+
+/**
+ * Manages zones based on JSON definitions.
+ */
+class ZoneRepository
+{
+    /**
+     * The path where zone definitions are stored.
+     *
+     * @var string
+     */
+    protected string $definitionPath;
+
+    /**
+     * Zone index.
+     *
+     * @var array
+     */
+    protected array $zoneIndex = [];
+
+    /**
+     * Zones.
+     *
+     * @var Zone[]
+     */
+    protected array $zones = [];
+
+    /**
+     * Creates a ZoneRepository instance.
+     *
+     * @param string $definitionPath Path to the zone definitions.
+     */
+    public function __construct(string $definitionPath)
+    {
+        $this->definitionPath = $definitionPath;
+    }
+
+    public function get(string $id): Zone
+    {
+        if (!isset($this->zones[$id])) {
+            $definition = $this->loadDefinition($id);
+            $this->zones[$id] = $this->createZoneFromDefinition($definition);
+        }
+
+        return $this->zones[$id];
+    }
+
+    public function getAll(?string $scope = null): array
+    {
+        // Build the list of all available zones.
+        if (empty($this->zoneIndex)) {
+            if ($handle = opendir($this->definitionPath)) {
+                while (false !== ($entry = readdir($handle))) {
+                    if (substr($entry, 0, 1) != '.') {
+                        $id = strtok($entry, '.');
+                        $this->zoneIndex[] = $id;
+                    }
+                }
+                closedir($handle);
+            }
+        }
+
+        // Load each zone, filter by scope if needed.
+        $zones = [];
+        foreach ($this->zoneIndex as $id) {
+            $zone = $this->get($id);
+            if (is_null($scope) || ($zone->getScope() == $scope)) {
+                $zones[$id] = $this->get($id);
+            }
+        }
+
+        return $zones;
+    }
+
+    /**
+     * Loads the zone definition for the provided id.
+     *
+     * @param string $id The zone id.
+     * @return array The zone definition.
+     */
+    protected function loadDefinition(string $id): array
+    {
+        $filename = $this->definitionPath . $id . '.json';
+        $definition = @file_get_contents($filename);
+        if (empty($definition)) {
+            throw new UnknownZoneException($id);
+        }
+        $definition = json_decode($definition, true);
+        $definition['id'] = $id;
+
+        return $definition;
+    }
+
+    /**
+     * Creates a Zone instance from the provided definition.
+     *
+     * @param array $definition The zone definition.
+     * @return Zone
+     */
+    protected function createZoneFromDefinition(array $definition): Zone
+    {
+        $definition['label'] = $definition['name'];
+
+        $territories = [];
+        foreach ($definition['members'] as $member) {
+            if ($member['type'] === 'zone') {
+                foreach ($this->loadDefinition($member['zone'])['members'] as $otherTerritory) {
+                    $territories[] = $otherTerritory;
+                }
+            } else {
+                $territories[] = $member;
+            }
+        }
+        $definition['territories'] = $territories;
+        return new Zone($definition);
+    }
+}

--- a/src/Resolver/TaxType/StoreRegistrationCheckerTrait.php
+++ b/src/Resolver/TaxType/StoreRegistrationCheckerTrait.php
@@ -3,9 +3,9 @@
 namespace CommerceGuys\Tax\Resolver\TaxType;
 
 use CommerceGuys\Addressing\Address;
+use CommerceGuys\Addressing\Zone\Zone;
 use CommerceGuys\Tax\Model\TaxTypeInterface;
 use CommerceGuys\Tax\Resolver\Context;
-use CommerceGuys\Zone\Model\ZoneInterface;
 
 trait StoreRegistrationCheckerTrait
 {
@@ -19,13 +19,13 @@ trait StoreRegistrationCheckerTrait
     /**
      * Checks whether the store is registered to collect taxes in the given zone.
      *
-     * @param ZoneInterface $zone    The zone.
+     * @param Zone $zone    The zone.
      * @param Context       $context The context containing store information.
      *
      * @return bool True if the store is registered to collect taxes in the
      *              given zone, false otherwise.
      */
-    protected function checkStoreRegistration(ZoneInterface $zone, Context $context)
+    protected function checkStoreRegistration(Zone $zone, Context $context)
     {
         $storeRegistrations = $context->getStoreRegistrations();
         foreach ($storeRegistrations as $country) {

--- a/tests/Model/TaxTypeTest.php
+++ b/tests/Model/TaxTypeTest.php
@@ -105,7 +105,8 @@ class TaxTypeTest extends TestCase
     public function testZone()
     {
         $zone = $this
-            ->getMockBuilder('CommerceGuys\Zone\Model\Zone')
+            ->getMockBuilder('CommerceGuys\Addressing\Zone\Zone')
+            ->setConstructorArgs([['id' => 'test', 'label' => 'test label', 'territories' => [['country_code' => 'test']]]])
             ->getMock();
 
         $this->taxType->setZone($zone);

--- a/tests/Repository/TaxTypeRepositoryTest.php
+++ b/tests/Repository/TaxTypeRepositoryTest.php
@@ -109,7 +109,7 @@ class TaxTypeRepositoryTest extends TestCase
     {
         $taxType = $this->taxTypeRepository->get('fr_vat');
         $this->assertInstanceOf('CommerceGuys\Tax\Model\TaxType', $taxType);
-        $this->assertInstanceOf('CommerceGuys\Zone\Model\Zone', $taxType->getZone());
+        $this->assertInstanceOf('CommerceGuys\Addressing\Zone\Zone', $taxType->getZone());
         $this->assertEquals('fr_vat', $taxType->getId());
         $this->assertEquals('French VAT', $taxType->getName());
         $this->assertEquals(GenericLabel::VAT, $taxType->getGenericLabel());
@@ -182,9 +182,9 @@ class TaxTypeRepositoryTest extends TestCase
      */
     protected function getZoneRepository()
     {
-        $zone = $this->createMock('CommerceGuys\Zone\Model\Zone');
+        $zone = $this->createMock('CommerceGuys\Addressing\Zone\Zone');
         $zoneRepository = $this
-            ->getMockBuilder('CommerceGuys\Zone\Repository\ZoneRepository')
+            ->getMockBuilder('CommerceGuys\Tax\Repository\ZoneRepository')
             ->disableOriginalConstructor()
             ->getMock();
         $zoneRepository

--- a/tests/Resolver/TaxRate/DefaultTaxRateResolverTest.php
+++ b/tests/Resolver/TaxRate/DefaultTaxRateResolverTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\TestCase;
  */
 class DefaultTaxRateResolverTest extends TestCase
 {
+    private ?DefaultTaxRateResolver $resolver = null;
+
     /**
      * {@inheritdoc}
      */

--- a/tests/Resolver/TaxType/EuTaxTypeResolverTest.php
+++ b/tests/Resolver/TaxType/EuTaxTypeResolverTest.php
@@ -7,6 +7,7 @@ use CommerceGuys\Tax\Repository\TaxTypeRepository;
 use CommerceGuys\Tax\Resolver\TaxType\EuTaxTypeResolver;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @coversDefaultClass \CommerceGuys\Tax\Resolver\TaxType\EuTaxTypeResolver
@@ -178,9 +179,10 @@ class EuTaxTypeResolverTest extends TestCase
      * @uses \CommerceGuys\Tax\Model\TaxType
      * @uses \CommerceGuys\Tax\Model\TaxRate
      * @uses \CommerceGuys\Tax\Model\TaxRateAmount
-     * @dataProvider dataProvider
+     * @dataProvider resolverProvider
      */
-    public function testResolver($taxable, $context, $expected)
+    #[DataProvider("resolverProvider")]
+    public function testResolver($taxable, $context, $expected): void
     {
         $resolver = $this->createResolver();
 
@@ -197,16 +199,19 @@ class EuTaxTypeResolverTest extends TestCase
     /**
      * Provides data for the resolver test.
      */
-    public function dataProvider()
+    public static function resolverProvider(): array
     {
-        $mockTaxableBuilder = $this->getMockBuilder('CommerceGuys\Tax\TaxableInterface');
+        $self = new self(self::class);
+
+        $mockTaxableBuilder = $self->getMockBuilder('CommerceGuys\Tax\TaxableInterface');
         $physicalTaxable = $mockTaxableBuilder->getMock();
-        $physicalTaxable->expects($this->any())
+
+        $physicalTaxable->expects($self->atLeastOnce())
             ->method('isPhysical')
-            ->will($this->returnValue(true));
+            ->will($self->returnValue(true));
         $digitalTaxable = $mockTaxableBuilder->getMock();
 
-        $serbianAddress = $this->createStub('CommerceGuys\Addressing\Address');
+        $serbianAddress = $self->createStub('CommerceGuys\Addressing\Address');
         $serbianAddress
             ->method('getCountryCode')
             ->willReturn('RS');
@@ -214,29 +219,30 @@ class EuTaxTypeResolverTest extends TestCase
             ->method('getPostalCode')
             ->willReturn('')
             ;
-        $frenchAddress = $this->createStub('CommerceGuys\Addressing\Address');
+        $frenchAddress = $self->createStub('CommerceGuys\Addressing\Address');
         $frenchAddress
             ->method('getCountryCode')
             ->willReturn('FR');
         $frenchAddress
             ->method('getPostalCode')
-            ->willreturn('')
+            ->willReturn('')
             ;
-        $germanAddress = $this->createStub('CommerceGuys\Addressing\Address');
+
+        $germanAddress = $self->createStub('CommerceGuys\Addressing\Address');
         $germanAddress
             ->method('getCountryCode')
             ->willReturn('DE');
         $germanAddress
             ->method('getPostalCode')
-            ->willreturn('')
+            ->willReturn('')
             ;
-        $usAddress = $this->createStub('CommerceGuys\Addressing\Address');
+        $usAddress = $self->createStub('CommerceGuys\Addressing\Address');
         $usAddress
             ->method('getCountryCode')
             ->willReturn('US');
         $usAddress
             ->method('getPostalCode')
-            ->willreturn('')
+            ->willReturn('')
             ;
 
         $date1 = new \DateTime('2014-02-24');
@@ -246,33 +252,33 @@ class EuTaxTypeResolverTest extends TestCase
 
         return [
             // German customer, French store, VAT number provided.
-            [$physicalTaxable, $this->getContext($germanAddress, $frenchAddress, '123'), 'eu_ic_vat'],
+            [$physicalTaxable, $self->getContext($germanAddress, $frenchAddress, '123'), 'eu_ic_vat'],
             // French customer, French store, VAT number provided.
-            [$physicalTaxable, $this->getContext($frenchAddress, $frenchAddress, '123'), 'fr_vat'],
+            [$physicalTaxable, $self->getContext($frenchAddress, $frenchAddress, '123'), 'fr_vat'],
             // German customer, French store, physical product.
-            [$physicalTaxable, $this->getContext($germanAddress, $frenchAddress, '', [], $date2), 'fr_vat'],
+            [$physicalTaxable, $self->getContext($germanAddress, $frenchAddress, '', [], $date2), 'fr_vat'],
             // German customer, French store registered for German VAT, physical product.
-            [$physicalTaxable, $this->getContext($germanAddress, $frenchAddress, '', ['DE'], $date2), 'de_vat'],
+            [$physicalTaxable, $self->getContext($germanAddress, $frenchAddress, '', ['DE'], $date2), 'de_vat'],
             // German customer, French store, digital product before Jan 1st 2015.
-            [$digitalTaxable, $this->getContext($germanAddress, $frenchAddress, '', [], $date1), 'fr_vat'],
+            [$digitalTaxable, $self->getContext($germanAddress, $frenchAddress, '', [], $date1), 'fr_vat'],
             // German customer, French store, digital product.
-            [$digitalTaxable, $this->getContext($germanAddress, $frenchAddress, '', [], $date2), 'de_vat'],
+            [$digitalTaxable, $self->getContext($germanAddress, $frenchAddress, '', [], $date2), 'de_vat'],
             // German customer, US store, digital product
-            [$digitalTaxable, $this->getContext($germanAddress, $usAddress, '', [], $date2), []],
+            [$digitalTaxable, $self->getContext($germanAddress, $usAddress, '', [], $date2), []],
             // German customer, US store registered in FR, digital product.
-            [$digitalTaxable, $this->getContext($germanAddress, $usAddress, '', ['FR'], $date2), 'de_vat'],
+            [$digitalTaxable, $self->getContext($germanAddress, $usAddress, '', ['FR'], $date2), 'de_vat'],
             // German customer with VAT number, US store registered in FR, digital product.
-            [$digitalTaxable, $this->getContext($germanAddress, $usAddress, '123', ['FR'], $date2), $notApplicable],
+            [$digitalTaxable, $self->getContext($germanAddress, $usAddress, '123', ['FR'], $date2), $notApplicable],
             // Serbian customer, French store, physical product.
-            [$physicalTaxable, $this->getContext($serbianAddress, $frenchAddress), []],
+            [$physicalTaxable, $self->getContext($serbianAddress, $frenchAddress), []],
             // French customer, Serbian store, physical product.
-            [$physicalTaxable, $this->getContext($frenchAddress, $serbianAddress), []],
+            [$physicalTaxable, $self->getContext($frenchAddress, $serbianAddress), []],
             // German customer, French store, digital product after July 1st 2021.
-            [$digitalTaxable, $this->getContext($germanAddress, $frenchAddress, '', [], $date3), 'de_vat'],
+            [$digitalTaxable, $self->getContext($germanAddress, $frenchAddress, '', [], $date3), 'de_vat'],
             // German customer, French store, physical product after July 1st 2021.
-            [$physicalTaxable, $this->getContext($germanAddress, $frenchAddress, '', [], $date3), 'de_vat'],
+            [$physicalTaxable, $self->getContext($germanAddress, $frenchAddress, '', [], $date3), 'de_vat'],
             // German customer US store registered in FR, physical product after July 1st 2021
-            [$physicalTaxable, $this->getContext($germanAddress, $usAddress, '', ['FR'], $date3), 'de_vat'],
+            [$physicalTaxable, $self->getContext($germanAddress, $usAddress, '', ['FR'], $date3), 'de_vat'],
         ];
     }
 


### PR DESCRIPTION
Need to upgrade phpunit too for mocking of classes with UnionTypes, which also means dropping support for PHP7.2/3.

Closes https://github.com/commerceguys/tax/issues/101.